### PR TITLE
Add dev environment setup script and agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent Guidelines for alexify
+
+This repository uses **Conventional Commits** for commit messages. Use the form
+`type(scope): short description` when committing. Common types are `feat`,
+`fix`, `docs`, `style`, `refactor`, `test` and `chore`.
+
+## Commit Rules
+- Keep commits atomic and logically scoped.
+- Run `pytest -q` before every commit and ensure it passes.
+- If `setup-dev.sh` modifies dependencies, update cached wheels via the script.
+
+## Pull Request Guidelines
+- Title should summarize the change.
+- In the body include a short description, testing steps and references.
+
+## Maintenance
+- Dependencies are defined in `requirements*.txt`. Keep them pinned.
+- Update changelog and bump version in `pyproject.toml` following Semantic
+  Versioning (`MAJOR.MINOR.PATCH`).
+- Pre-commit hooks (if `.pre-commit-config.yaml` exists) must run before
+  committing.
+

--- a/README.md
+++ b/README.md
@@ -110,3 +110,10 @@ alexify missing /mybibfiles-oa.bib
 
 This project is licensed under the MIT License.
 
+## Development
+
+To set up a development environment with all dependencies and cached wheels, run
+`./setup-dev.sh` while online. The script installs required system packages,
+creates a Python virtual environment and runs the test suite to verify the
+setup.
+

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+# setup-dev.sh - Prepare isolated development environment for alexify
+# This script installs system packages, creates a Python virtual environment,
+# downloads all Python dependencies, installs them, and runs a basic test to
+# verify the setup. Run once while online.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CACHE_DIR="$ROOT/.cache/pip"
+
+# Ensure apt packages are installed
+need_pkg() {
+    dpkg -s "$1" &>/dev/null || return 0
+}
+
+sudo apt-get update
+sudo apt-get install -y python3 python3-venv python3-dev build-essential git
+
+# Create virtual environment if missing
+if [ ! -d "$ROOT/.venv" ]; then
+    python3 -m venv "$ROOT/.venv"
+fi
+
+source "$ROOT/.venv/bin/activate"
+
+# Upgrade pip and ensure wheel
+pip install --upgrade pip wheel
+
+mkdir -p "$CACHE_DIR"
+
+# Download dependencies for offline use
+pip download -d "$CACHE_DIR" -r "$ROOT/requirements-dev.txt"
+
+# Install requirements online now (packages are also cached for offline reuse)
+pip install -r "$ROOT/requirements-dev.txt"
+
+# Install poetry for convenience
+if ! command -v poetry >/dev/null 2>&1; then
+    pip install poetry
+fi
+
+# Install pre-commit hooks if configuration present
+if [ -f "$ROOT/.pre-commit-config.yaml" ]; then
+    pre-commit install
+fi
+
+# Run tests to confirm everything works
+pytest -q
+
+echo "Development environment setup complete."


### PR DESCRIPTION
## Summary
- provide setup-dev.sh for offline-ready development environment
- document commit and PR rules in AGENTS.md
- mention new setup script in README

## Testing
- `./setup-dev.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68494700fab4832b9f0af7f140eaf5d6