### PR TITLE
Fix concurrent candidate scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Avoid TypeError when candidate scores tie in concurrent scoring
+
 ## [0.4.1] - 2025-01-20
 - Fix pickling error in concurrent processing by moving `compute_score` to module level
 - Fix Retry-After header parsing to handle both numeric and date string formats

--- a/alexify/core_concurrent.py
+++ b/alexify/core_concurrent.py
@@ -106,7 +106,8 @@ def score_candidates_concurrent(
     ) as executor:
         scored = list(executor.map(_compute_score_for_entry, args_list))
 
-    return sorted(scored, reverse=True)
+    # Sort by score only; avoid comparing dicts when scores tie
+    return sorted(scored, key=lambda x: x[0], reverse=True)
 
 
 async def process_bib_entry_by_title_async(


### PR DESCRIPTION
## Summary
- prevent TypeError when sorting scored candidates in concurrent mode
- document fix in CHANGELOG

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685595a7c2e4832bb3d561af28ffbfe2